### PR TITLE
[Deps] add missing `call-bind`

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
 		"version": "auto-changelog && git add CHANGELOG.md",
 		"postversion": "auto-changelog && git add CHANGELOG.md && git commit --no-edit --amend && git tag -f \"v$(node -e \"console.log(require('./package.json').version)\")\""
 	},
+	"dependencies": {
+		"call-bind": "^1.0.2"
+	},
 	"devDependencies": {
 		"@ljharb/eslint-config": "^21.1.0",
 		"aud": "^2.0.3",


### PR DESCRIPTION
Fixes #1 
Add [`call-bind`](https://www.npmjs.com/package/call-bind) to package.json `dependencies`